### PR TITLE
fixes #2 & modernizes codebase

### DIFF
--- a/AudioSwitcher.xcodeproj/project.pbxproj
+++ b/AudioSwitcher.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -110,9 +110,16 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+			};
 			buildConfigurationList = 1DEB926208733DCF0010E9CD /* Build configuration list for PBXProject "AudioSwitcher" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* AudioSwitcher */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -163,26 +170,24 @@
 		1DEB926308733DCF0010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		1DEB926408733DCF0010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/AudioSwitcher.xcodeproj/project.pbxproj
+++ b/AudioSwitcher.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
 				PRODUCT_NAME = AudioSwitcher;
 			};
 			name = Debug;
@@ -163,6 +164,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
 				PRODUCT_NAME = SwitchAudioSource;
 			};
 			name = Release;

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -31,317 +31,317 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 void showUsage(const char * appName) {
-	printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name\n  -a             : shows all devices\n  -c             : shows current device\n\n  -t type        : device type (input/output/system).  Defaults to output.\n  -n             : cycles the audio device to the next one\n  -s device_name : sets the audio device to the given device by name\n\n",appName);
+    printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name\n  -a             : shows all devices\n  -c             : shows current device\n\n  -t type        : device type (input/output/system).  Defaults to output.\n  -n             : cycles the audio device to the next one\n  -s device_name : sets the audio device to the given device by name\n\n",appName);
 }
 
 int runAudioSwitch(int argc, const char * argv[]) {
-	char requestedDeviceName[256];
-	AudioDeviceID chosenDeviceID = kAudioDeviceUnknown;
-	ASDeviceType typeRequested = kAudioTypeUnknown;
-	int function = 0;
+    char requestedDeviceName[256];
+    AudioDeviceID chosenDeviceID = kAudioDeviceUnknown;
+    ASDeviceType typeRequested = kAudioTypeUnknown;
+    int function = 0;
 
-	int c;
-	while ((c = getopt(argc, (char **)argv, "hacnt:s:")) != -1) {
-		switch (c) {
-			case 'a':
-				// show all
-				function = kFunctionShowAll;
-				break;
-			case 'c':
-				// get current device
-				function = kFunctionShowCurrent;
-				break;
+    int c;
+    while ((c = getopt(argc, (char **)argv, "hacnt:s:")) != -1) {
+        switch (c) {
+            case 'a':
+                // show all
+                function = kFunctionShowAll;
+                break;
+            case 'c':
+                // get current device
+                function = kFunctionShowCurrent;
+                break;
 
-			case 'h':
-				// show help
-				function = kFunctionShowHelp;
-				break;
-				
-			case 'n':
-				// cycle to the next audio device
-				function = kFunctionCycleNext;
-				break;
-				
-			case 's':
-				// set the requestedDeviceName
-				function = kFunctionSetDevice;
-				strcpy(requestedDeviceName, optarg);
-				break;
+            case 'h':
+                // show help
+                function = kFunctionShowHelp;
+                break;
 
-			case 't':
-				// set the requestedDeviceName
-				if (strcmp(optarg, "input") == 0) {
-					typeRequested = kAudioTypeInput;
-				} else if (strcmp(optarg, "output") == 0) {
-					typeRequested = kAudioTypeOutput;
-				} else if (strcmp(optarg, "system") == 0) {
-					typeRequested = kAudioTypeSystemOutput;
-				} else {
-					printf("Invalid device type \"%s\" specified.\n",optarg);
-					showUsage(argv[0]);
-					return 1;
-				}
-				break;
-		}
-	}
-	
-	if (function == kFunctionShowAll) {
-		switch(typeRequested) {
-			case kAudioTypeInput:
-			case kAudioTypeOutput:
-				showAllDevices(typeRequested);
-				break;
-			case kAudioTypeSystemOutput:
-				showAllDevices(kAudioTypeOutput);
-				break;
-			default:
-				showAllDevices(kAudioTypeInput);
-				showAllDevices(kAudioTypeOutput);
-		}
-		return 0;
-	}
-	if (function == kFunctionShowHelp) {
-		showUsage(argv[0]);
-		return 0;
-	}
-	if (function == kFunctionShowCurrent) {
-		if (typeRequested == kAudioTypeUnknown) typeRequested = kAudioTypeOutput;
-		showCurrentlySelectedDeviceID(typeRequested);
-		return 0;
-	}
+            case 'n':
+                // cycle to the next audio device
+                function = kFunctionCycleNext;
+                break;
 
-	if (typeRequested == kAudioTypeUnknown) typeRequested = kAudioTypeOutput;
+            case 's':
+                // set the requestedDeviceName
+                function = kFunctionSetDevice;
+                strcpy(requestedDeviceName, optarg);
+                break;
 
-	if (function == kFunctionCycleNext) {
-		// get current device of requested type
-		chosenDeviceID = getCurrentlySelectedDeviceID(typeRequested);
-		if (chosenDeviceID == kAudioDeviceUnknown) {
-			printf("Could not find current audio device of type %s.  Nothing was changed.\n", deviceTypeName(typeRequested));
-			return 1;
-		}
+            case 't':
+                // set the requestedDeviceName
+                if (strcmp(optarg, "input") == 0) {
+                    typeRequested = kAudioTypeInput;
+                } else if (strcmp(optarg, "output") == 0) {
+                    typeRequested = kAudioTypeOutput;
+                } else if (strcmp(optarg, "system") == 0) {
+                    typeRequested = kAudioTypeSystemOutput;
+                } else {
+                    printf("Invalid device type \"%s\" specified.\n",optarg);
+                    showUsage(argv[0]);
+                    return 1;
+                }
+                break;
+        }
+    }
 
-		// find next device to current device
-		chosenDeviceID = getNextDeviceID(chosenDeviceID, typeRequested);
-		if (chosenDeviceID == kAudioDeviceUnknown) {
-			printf("Could not find next audio device of type %s.  Nothing was changed.\n", deviceTypeName(typeRequested));
-			return 1;
-		}
-		
-		// choose the requested audio device
-		setDevice(chosenDeviceID, typeRequested);
-		getDeviceName(chosenDeviceID, requestedDeviceName);
-		printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), requestedDeviceName);
-		
-		return 0;
-	}
-	
-	if (function != kFunctionSetDevice) {
-		printf("Please specify audio device.\n");
-		showUsage(argv[0]);
-		return 1;
-	}
-	
-	// find the id of the requested device
-	chosenDeviceID = getRequestedDeviceID(requestedDeviceName, typeRequested);
-	if (chosenDeviceID == kAudioDeviceUnknown) {
-		printf("Could not find an audio device named \"%s\" of type %s.  Nothing was changed.\n",requestedDeviceName, deviceTypeName(typeRequested));
-		return 1;
-	}
-	
-	// choose the requested audio device
-	setDevice(chosenDeviceID, typeRequested);
-	printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), requestedDeviceName);
-	return 0;
-	
+    if (function == kFunctionShowAll) {
+        switch(typeRequested) {
+            case kAudioTypeInput:
+            case kAudioTypeOutput:
+                showAllDevices(typeRequested);
+                break;
+            case kAudioTypeSystemOutput:
+                showAllDevices(kAudioTypeOutput);
+                break;
+            default:
+                showAllDevices(kAudioTypeInput);
+                showAllDevices(kAudioTypeOutput);
+        }
+        return 0;
+    }
+    if (function == kFunctionShowHelp) {
+        showUsage(argv[0]);
+        return 0;
+    }
+    if (function == kFunctionShowCurrent) {
+        if (typeRequested == kAudioTypeUnknown) typeRequested = kAudioTypeOutput;
+        showCurrentlySelectedDeviceID(typeRequested);
+        return 0;
+    }
+
+    if (typeRequested == kAudioTypeUnknown) typeRequested = kAudioTypeOutput;
+
+    if (function == kFunctionCycleNext) {
+        // get current device of requested type
+        chosenDeviceID = getCurrentlySelectedDeviceID(typeRequested);
+        if (chosenDeviceID == kAudioDeviceUnknown) {
+            printf("Could not find current audio device of type %s.  Nothing was changed.\n", deviceTypeName(typeRequested));
+            return 1;
+        }
+
+        // find next device to current device
+        chosenDeviceID = getNextDeviceID(chosenDeviceID, typeRequested);
+        if (chosenDeviceID == kAudioDeviceUnknown) {
+            printf("Could not find next audio device of type %s.  Nothing was changed.\n", deviceTypeName(typeRequested));
+            return 1;
+        }
+
+        // choose the requested audio device
+        setDevice(chosenDeviceID, typeRequested);
+        getDeviceName(chosenDeviceID, requestedDeviceName);
+        printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), requestedDeviceName);
+
+        return 0;
+    }
+
+    if (function != kFunctionSetDevice) {
+        printf("Please specify audio device.\n");
+        showUsage(argv[0]);
+        return 1;
+    }
+
+    // find the id of the requested device
+    chosenDeviceID = getRequestedDeviceID(requestedDeviceName, typeRequested);
+    if (chosenDeviceID == kAudioDeviceUnknown) {
+        printf("Could not find an audio device named \"%s\" of type %s.  Nothing was changed.\n",requestedDeviceName, deviceTypeName(typeRequested));
+        return 1;
+    }
+
+    // choose the requested audio device
+    setDevice(chosenDeviceID, typeRequested);
+    printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), requestedDeviceName);
+    return 0;
+
 }
 
 
 AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
-	UInt32 propertySize;
-	AudioDeviceID deviceID = kAudioDeviceUnknown;
+    UInt32 propertySize;
+    AudioDeviceID deviceID = kAudioDeviceUnknown;
 
-	propertySize = sizeof(deviceID);
-	switch(typeRequested) {
-		case kAudioTypeInput: 
-			AudioHardwareGetProperty(kAudioHardwarePropertyDefaultInputDevice, &propertySize, &deviceID);
-			break;
-		case kAudioTypeOutput:
-			AudioHardwareGetProperty(kAudioHardwarePropertyDefaultOutputDevice, &propertySize, &deviceID);
-			break;
-		case kAudioTypeSystemOutput:
-			AudioHardwareGetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, &propertySize, &deviceID);
-			break;
+    propertySize = sizeof(deviceID);
+    switch(typeRequested) {
+        case kAudioTypeInput: 
+            AudioHardwareGetProperty(kAudioHardwarePropertyDefaultInputDevice, &propertySize, &deviceID);
+            break;
+        case kAudioTypeOutput:
+            AudioHardwareGetProperty(kAudioHardwarePropertyDefaultOutputDevice, &propertySize, &deviceID);
+            break;
+        case kAudioTypeSystemOutput:
+            AudioHardwareGetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, &propertySize, &deviceID);
+            break;
         default:
             break;
-	}
-	
-	return deviceID;
+    }
+
+    return deviceID;
 }
 
 void getDeviceName(AudioDeviceID deviceID, char * deviceName) {
-	UInt32 propertySize = 256;
-	AudioDeviceGetProperty(deviceID, 0, false, kAudioDevicePropertyDeviceName, &propertySize, deviceName);  
+    UInt32 propertySize = 256;
+    AudioDeviceGetProperty(deviceID, 0, false, kAudioDevicePropertyDeviceName, &propertySize, deviceName);
 }
 
 // returns kAudioTypeInput or kAudioTypeOutput
 ASDeviceType getDeviceType(AudioDeviceID deviceID) {
-	UInt32 propertySize = 256;
-	
-	// if there are any output streams, then it is an output
-	AudioDeviceGetPropertyInfo(deviceID, 0, false, kAudioDevicePropertyStreams, &propertySize, NULL);
-	if (propertySize > 0) return kAudioTypeOutput;
-	
-	// if there are any input streams, then it is an input
-	AudioDeviceGetPropertyInfo(deviceID, 0, true, kAudioDevicePropertyStreams, &propertySize, NULL);
-	if (propertySize > 0) return kAudioTypeInput;
-	
-	return kAudioTypeUnknown;
+    UInt32 propertySize = 256;
+
+    // if there are any output streams, then it is an output
+    AudioDeviceGetPropertyInfo(deviceID, 0, false, kAudioDevicePropertyStreams, &propertySize, NULL);
+    if (propertySize > 0) return kAudioTypeOutput;
+
+    // if there are any input streams, then it is an input
+    AudioDeviceGetPropertyInfo(deviceID, 0, true, kAudioDevicePropertyStreams, &propertySize, NULL);
+    if (propertySize > 0) return kAudioTypeInput;
+
+    return kAudioTypeUnknown;
 }
 
 char *deviceTypeName(ASDeviceType device_type) {
-	switch(device_type) {
-		case kAudioTypeInput: return "input";
-		case kAudioTypeOutput: return "output";
-		case kAudioTypeSystemOutput: return "system";
+    switch(device_type) {
+        case kAudioTypeInput: return "input";
+        case kAudioTypeOutput: return "output";
+        case kAudioTypeSystemOutput: return "system";
         default:
             break;
-	}
-	return "unknown";
+    }
+    return "unknown";
 }
 
 void showCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
-	AudioDeviceID currentDeviceID = kAudioDeviceUnknown;
-	char currentDeviceName[256];
-	
-	currentDeviceID = getCurrentlySelectedDeviceID(typeRequested);
-	getDeviceName(currentDeviceID, currentDeviceName);
-	printf("%s\n",currentDeviceName);
+    AudioDeviceID currentDeviceID = kAudioDeviceUnknown;
+    char currentDeviceName[256];
+
+    currentDeviceID = getCurrentlySelectedDeviceID(typeRequested);
+    getDeviceName(currentDeviceID, currentDeviceName);
+    printf("%s\n",currentDeviceName);
 }
 
 
 AudioDeviceID getRequestedDeviceID(char * requestedDeviceName, ASDeviceType typeRequested) {
-	UInt32 propertySize;
-	AudioDeviceID dev_array[64];
-	int numberOfDevices = 0;
-	char deviceName[256];
-	
-	AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
-	// printf("propertySize=%d\n",propertySize);
-	
-	AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
-	numberOfDevices = (propertySize / sizeof(AudioDeviceID));
-	// printf("numberOfDevices=%d\n",numberOfDevices);
-	
-	for(int i = 0; i < numberOfDevices; ++i) {
-		switch(typeRequested) {
-			case kAudioTypeInput:
-			case kAudioTypeOutput:
-				if (getDeviceType(dev_array[i]) != typeRequested) continue;
-				break;
-			case kAudioTypeSystemOutput:
-				if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
-				break;
+    UInt32 propertySize;
+    AudioDeviceID dev_array[64];
+    int numberOfDevices = 0;
+    char deviceName[256];
+
+    AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
+    // printf("propertySize=%d\n",propertySize);
+
+    AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
+    numberOfDevices = (propertySize / sizeof(AudioDeviceID));
+    // printf("numberOfDevices=%d\n",numberOfDevices);
+
+    for(int i = 0; i < numberOfDevices; ++i) {
+        switch(typeRequested) {
+            case kAudioTypeInput:
+            case kAudioTypeOutput:
+                if (getDeviceType(dev_array[i]) != typeRequested) continue;
+                break;
+            case kAudioTypeSystemOutput:
+                if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
+                break;
             default:
                 return kAudioDeviceUnknown;
-		}
-		
-		getDeviceName(dev_array[i], deviceName);
-		// printf("For device %d, id = %d and name is %s\n",i,dev_array[i],deviceName);
-		if (strcmp(requestedDeviceName, deviceName) == 0) {
-			return dev_array[i];
-		}
-	}
-	
-	return kAudioDeviceUnknown;
+        }
+
+        getDeviceName(dev_array[i], deviceName);
+        // printf("For device %d, id = %d and name is %s\n",i,dev_array[i],deviceName);
+        if (strcmp(requestedDeviceName, deviceName) == 0) {
+            return dev_array[i];
+        }
+    }
+
+    return kAudioDeviceUnknown;
 }
 
 AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRequested) {
-	UInt32 propertySize;
-	AudioDeviceID dev_array[64];
-	int numberOfDevices = 0;
-	AudioDeviceID first_dev = kAudioDeviceUnknown;
-	int found = -1;
-	
-	AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
-	// printf("propertySize=%d\n",propertySize);
-	
-	AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
-	numberOfDevices = (propertySize / sizeof(AudioDeviceID));
-	// printf("numberOfDevices=%d\n",numberOfDevices);
-	
-	for(int i = 0; i < numberOfDevices; ++i) {
-		switch(typeRequested) {
-			case kAudioTypeInput:
-			case kAudioTypeOutput:
-				if (getDeviceType(dev_array[i]) != typeRequested) continue;
-				break;
-			case kAudioTypeSystemOutput:
-				if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
-				break;
+    UInt32 propertySize;
+    AudioDeviceID dev_array[64];
+    int numberOfDevices = 0;
+    AudioDeviceID first_dev = kAudioDeviceUnknown;
+    int found = -1;
+
+    AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
+    // printf("propertySize=%d\n",propertySize);
+
+    AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
+    numberOfDevices = (propertySize / sizeof(AudioDeviceID));
+    // printf("numberOfDevices=%d\n",numberOfDevices);
+
+    for(int i = 0; i < numberOfDevices; ++i) {
+        switch(typeRequested) {
+            case kAudioTypeInput:
+            case kAudioTypeOutput:
+                if (getDeviceType(dev_array[i]) != typeRequested) continue;
+                break;
+            case kAudioTypeSystemOutput:
+                if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
+                break;
             case kAudioTypeUnknown:
                 return kAudioDeviceUnknown;
-		}
+        }
 
-		if (first_dev == kAudioDeviceUnknown) {
-			first_dev = dev_array[i];
-		}
-		if (found >= 0) {
-			return dev_array[i];
-		}
-		if (dev_array[i] == currentDeviceID) {
-			found = i;
-		}
-	}
-	
-	return first_dev;
+        if (first_dev == kAudioDeviceUnknown) {
+            first_dev = dev_array[i];
+        }
+        if (found >= 0) {
+            return dev_array[i];
+        }
+        if (dev_array[i] == currentDeviceID) {
+            found = i;
+        }
+    }
+
+    return first_dev;
 }
 
 void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested) {
-	UInt32 propertySize = sizeof(UInt32);
+    UInt32 propertySize = sizeof(UInt32);
 
-	switch(typeRequested) {
-		case kAudioTypeInput: 
-			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultInputDevice, propertySize, &newDeviceID);
-			break;
-		case kAudioTypeOutput:
-			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultOutputDevice, propertySize, &newDeviceID);
-			break;
-		case kAudioTypeSystemOutput:
-			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, propertySize, &newDeviceID);
-			break;
+    switch(typeRequested) {
+        case kAudioTypeInput: 
+            AudioHardwareSetProperty(kAudioHardwarePropertyDefaultInputDevice, propertySize, &newDeviceID);
+            break;
+        case kAudioTypeOutput:
+            AudioHardwareSetProperty(kAudioHardwarePropertyDefaultOutputDevice, propertySize, &newDeviceID);
+            break;
+        case kAudioTypeSystemOutput:
+            AudioHardwareSetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, propertySize, &newDeviceID);
+            break;
         default:
             break;
-	}
-	
+    }
+
 }
 
 void showAllDevices(ASDeviceType typeRequested) {
-	UInt32 propertySize;
-	AudioDeviceID dev_array[64];
-	int numberOfDevices = 0;
-	ASDeviceType device_type;
-	char deviceName[256];
-	
-	AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
-	
-	AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
-	numberOfDevices = (propertySize / sizeof(AudioDeviceID));
-	
-	for(int i = 0; i < numberOfDevices; ++i) {
-		device_type = getDeviceType(dev_array[i]);
-		switch(typeRequested) {
-			case kAudioTypeInput:
-			case kAudioTypeOutput:
-				if (device_type != typeRequested) continue;
-				break;
-			case kAudioTypeSystemOutput:
-				if (device_type != kAudioTypeOutput) continue;
-				break;
+    UInt32 propertySize;
+    AudioDeviceID dev_array[64];
+    int numberOfDevices = 0;
+    ASDeviceType device_type;
+    char deviceName[256];
+
+    AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
+
+    AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
+    numberOfDevices = (propertySize / sizeof(AudioDeviceID));
+
+    for(int i = 0; i < numberOfDevices; ++i) {
+        device_type = getDeviceType(dev_array[i]);
+        switch(typeRequested) {
+            case kAudioTypeInput:
+            case kAudioTypeOutput:
+                if (device_type != typeRequested) continue;
+                break;
+            case kAudioTypeSystemOutput:
+                if (device_type != kAudioTypeOutput) continue;
+                break;
             default:
                 return;
-		}
-		
-		getDeviceName(dev_array[i], deviceName);
-		printf("%s (%s)\n",deviceName,deviceTypeName(device_type));
-	}
+        }
+
+        getDeviceName(dev_array[i], deviceName);
+        printf("%s (%s)\n",deviceName,deviceTypeName(device_type));
+    }
 }

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -172,7 +172,8 @@ AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
 		case kAudioTypeSystemOutput:
 			AudioHardwareGetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, &propertySize, &deviceID);
 			break;
-			
+        default:
+            break;
 	}
 	
 	return deviceID;
@@ -203,6 +204,8 @@ char *deviceTypeName(ASDeviceType device_type) {
 		case kAudioTypeInput: return "input";
 		case kAudioTypeOutput: return "output";
 		case kAudioTypeSystemOutput: return "system";
+        default:
+            break;
 	}
 	return "unknown";
 }
@@ -239,6 +242,8 @@ AudioDeviceID getRequestedDeviceID(char * requestedDeviceName, ASDeviceType type
 			case kAudioTypeSystemOutput:
 				if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
 				break;
+            default:
+                return kAudioDeviceUnknown;
 		}
 		
 		getDeviceName(dev_array[i], deviceName);
@@ -274,6 +279,8 @@ AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRe
 			case kAudioTypeSystemOutput:
 				if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
 				break;
+            case kAudioTypeUnknown:
+                return kAudioDeviceUnknown;
 		}
 
 		if (first_dev == kAudioDeviceUnknown) {
@@ -303,6 +310,8 @@ void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested) {
 		case kAudioTypeSystemOutput:
 			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, propertySize, &newDeviceID);
 			break;
+        default:
+            break;
 	}
 	
 }
@@ -329,6 +338,8 @@ void showAllDevices(ASDeviceType typeRequested) {
 			case kAudioTypeSystemOutput:
 				if (device_type != kAudioTypeOutput) continue;
 				break;
+            default:
+                return;
 		}
 		
 		getDeviceName(dev_array[i], deviceName);

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -159,8 +159,7 @@ int runAudioSwitch(int argc, const char * argv[]) {
 AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
 	UInt32 propertySize;
 	AudioDeviceID deviceID = kAudioDeviceUnknown;
-	
-	// get the default output device
+
 	propertySize = sizeof(deviceID);
 	switch(typeRequested) {
 		case kAudioTypeInput: 

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -33,23 +33,20 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <CoreServices/CoreServices.h>
 #include <CoreAudio/CoreAudio.h>
 
-
 typedef enum { 
-  	kAudioTypeUnknown = 0, 
-    kAudioTypeInput   = 1, 
+    kAudioTypeUnknown = 0,
+    kAudioTypeInput   = 1,
     kAudioTypeOutput  = 2,
     kAudioTypeSystemOutput = 3
 } ASDeviceType;
 
 enum {
-	kFunctionSetDevice   = 1,
-	kFunctionShowHelp    = 2,
-	kFunctionShowAll     = 3,
-	kFunctionShowCurrent = 4,
-	kFunctionCycleNext   = 5
+    kFunctionSetDevice   = 1,
+    kFunctionShowHelp    = 2,
+    kFunctionShowAll     = 3,
+    kFunctionShowCurrent = 4,
+    kFunctionCycleNext   = 5
 };
-
-
 
 void showUsage(const char * appName);
 int runAudioSwitch(int argc, const char * argv[]);
@@ -62,4 +59,3 @@ AudioDeviceID getRequestedDeviceID(char * requestedDeviceName, ASDeviceType type
 AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRequested);
 void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested);
 void showAllDevices(ASDeviceType typeRequested);
-

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -34,10 +34,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <CoreAudio/CoreAudio.h>
 
 typedef enum { 
-    kAudioTypeUnknown = 0,
-    kAudioTypeInput   = 1,
-    kAudioTypeOutput  = 2,
-    kAudioTypeSystemOutput = 3
+    kAudioTypeUnknown      = 0,
+    kAudioTypeInput        = 1,
+    kAudioTypeOutput       = 2,
+    kAudioTypeInputOutput  = 3,
+    kAudioTypeSystemOutput = 4
 } ASDeviceType;
 
 enum {

--- a/main.c
+++ b/main.c
@@ -1,8 +1,5 @@
 #include "audio_switch.h"
 
-
-
 int main (int argc, const char * argv[]) {
-	return runAudioSwitch(argc, argv);
+    return runAudioSwitch(argc, argv);
 }
-


### PR DESCRIPTION
All commits here but the last update the codebase for: 
- Xcode 5.1.1
- 10.9 SDK & 10.4 deployment
- tabs `->` spaces for indentation
- migrate 10.6-deprecated API (`AudioHardwareGetProperty -> AudioObjectGetPropertyData`, etc.)
- fix some compiler warnings

Then, the last commit fixes #2 and allows for an audio device (e.g., `Display Audio`) to serve as both an input and an output option if appropriate. 
